### PR TITLE
[FEAT] 홈화면 가로 스크롤 아이템 제작

### DIFF
--- a/Cproject/Feature/Home/Home.storyboard
+++ b/Cproject/Feature/Home/Home.storyboard
@@ -3,6 +3,7 @@
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="collection view cell content view" minToolsVersion="11.0"/>
@@ -50,6 +51,79 @@
                                             <outlet property="imageView" destination="JwU-hc-BqW" id="fig-Tu-hVr"/>
                                         </connections>
                                     </collectionViewCell>
+                                    <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="HomeProductCell" id="qXh-U1-YLt" customClass="HomeProductCell" customModule="Cproject" customModuleProvider="target">
+                                        <rect key="frame" x="76.666666666666671" y="239" width="240" height="331.33333333333326"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="62o-hi-JUN">
+                                            <rect key="frame" x="0.0" y="0.0" width="240" height="331.33333333333326"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="spr-P1-83x">
+                                                    <rect key="frame" x="0.0" y="0.0" width="240" height="331.33333333333331"/>
+                                                    <subviews>
+                                                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Ce0-jy-x1G">
+                                                            <rect key="frame" x="0.0" y="0.0" width="240" height="240"/>
+                                                            <constraints>
+                                                                <constraint firstAttribute="width" secondItem="Ce0-jy-x1G" secondAttribute="height" multiplier="1:1" id="CaB-Gl-7em"/>
+                                                            </constraints>
+                                                        </imageView>
+                                                        <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="13" translatesAutoresizingMaskIntoConstraints="NO" id="wUG-Vd-c4s">
+                                                            <rect key="frame" x="0.0" y="252.00000000000003" width="240" height="79.333333333333343"/>
+                                                            <subviews>
+                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="t7x-tp-7nm">
+                                                                    <rect key="frame" x="0.0" y="0.0" width="240" height="17"/>
+                                                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                                    <color key="textColor" name="bk"/>
+                                                                    <nil key="highlightedColor"/>
+                                                                </label>
+                                                                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="G48-1k-8Pz">
+                                                                    <rect key="frame" x="0.0" y="30.000000000000004" width="240" height="49.333333333333343"/>
+                                                                    <subviews>
+                                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="h61-xq-fJf">
+                                                                            <rect key="frame" x="0.0" y="0.0" width="240" height="12"/>
+                                                                            <fontDescription key="fontDescription" type="system" pointSize="10"/>
+                                                                            <color key="textColor" name="key-color-red-2"/>
+                                                                            <nil key="highlightedColor"/>
+                                                                        </label>
+                                                                        <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="1" translatesAutoresizingMaskIntoConstraints="NO" id="szm-dV-P2e">
+                                                                            <rect key="frame" x="0.0" y="17.000000000000004" width="240" height="32.333333333333343"/>
+                                                                            <subviews>
+                                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ldy-9u-raW">
+                                                                                    <rect key="frame" x="0.0" y="0.0" width="240" height="14.333333333333334"/>
+                                                                                    <fontDescription key="fontDescription" type="system" weight="medium" pointSize="12"/>
+                                                                                    <color key="textColor" name="gray-4"/>
+                                                                                    <nil key="highlightedColor"/>
+                                                                                </label>
+                                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Jjw-zh-v6W">
+                                                                                    <rect key="frame" x="0.0" y="15.333333333333314" width="240" height="17"/>
+                                                                                    <fontDescription key="fontDescription" type="boldSystem" pointSize="14"/>
+                                                                                    <color key="textColor" name="key-color-red"/>
+                                                                                    <nil key="highlightedColor"/>
+                                                                                </label>
+                                                                            </subviews>
+                                                                        </stackView>
+                                                                    </subviews>
+                                                                </stackView>
+                                                            </subviews>
+                                                        </stackView>
+                                                    </subviews>
+                                                </stackView>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstAttribute="trailing" secondItem="spr-P1-83x" secondAttribute="trailing" id="9Z6-7E-RfV"/>
+                                                <constraint firstItem="spr-P1-83x" firstAttribute="leading" secondItem="62o-hi-JUN" secondAttribute="leading" id="R0i-Ac-ECW"/>
+                                                <constraint firstAttribute="bottom" secondItem="spr-P1-83x" secondAttribute="bottom" id="Ydr-78-r1B"/>
+                                                <constraint firstItem="spr-P1-83x" firstAttribute="top" secondItem="62o-hi-JUN" secondAttribute="top" id="fVe-qY-DLj"/>
+                                            </constraints>
+                                        </collectionViewCellContentView>
+                                        <connections>
+                                            <outlet property="discountLabel" destination="Jjw-zh-v6W" id="C4n-qi-qvF"/>
+                                            <outlet property="imageView" destination="Ce0-jy-x1G" id="396-Ki-YF0"/>
+                                            <outlet property="originalLabel" destination="Ldy-9u-raW" id="8LM-rP-hZl"/>
+                                            <outlet property="reasonDiscountLabel" destination="h61-xq-fJf" id="3KM-aT-HBq"/>
+                                            <outlet property="titleLabel" destination="t7x-tp-7nm" id="F1K-t3-Q7a"/>
+                                        </connections>
+                                    </collectionViewCell>
                                 </cells>
                             </collectionView>
                         </subviews>
@@ -72,6 +146,18 @@
         </scene>
     </scenes>
     <resources>
+        <namedColor name="bk">
+            <color red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <namedColor name="gray-4">
+            <color red="0.70980392156862748" green="0.73333333333333328" blue="0.76078431372549016" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <namedColor name="key-color-red">
+            <color red="0.81568627450980391" green="0.23137254901960785" blue="0.19607843137254902" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <namedColor name="key-color-red-2">
+            <color red="0.88235294117647056" green="0.396078431372549" blue="0.39215686274509803" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>

--- a/Cproject/Feature/Home/HomeBannerCell.swift
+++ b/Cproject/Feature/Home/HomeBannerCell.swift
@@ -7,11 +7,15 @@
 
 import UIKit
 
+struct HomeBannerCellViewModel: Hashable{
+    let bannerImage: UIImage
+}
+
 class HomeBannerCell: UICollectionViewCell {
     
     @IBOutlet weak var imageView: UIImageView!
     
-    func configure(_ image: UIImage){
-        imageView.image = image
+    func configure(_ viewModel: HomeBannerCellViewModel){
+        imageView.image = viewModel.bannerImage
     }
 }

--- a/Cproject/Feature/Home/HomeProductCell.swift
+++ b/Cproject/Feature/Home/HomeProductCell.swift
@@ -1,0 +1,36 @@
+//
+//  HomeProductCell.swift
+//  Cproject
+//
+//  Created by wodnd on 4/1/25.
+//
+
+import UIKit
+
+struct HomeProductCellViewModel: Hashable {
+    let imageUlrString: String
+    let title: String
+    let reasonDiscountString: String
+    let originalPriceString: String
+    let discountPriceString: String
+}
+
+class HomeProductCell: UICollectionViewCell {
+    
+    @IBOutlet weak var imageView: UIImageView!
+    @IBOutlet weak var titleLabel: UILabel!
+    @IBOutlet weak var reasonDiscountLabel: UILabel!
+    @IBOutlet weak var originalLabel: UILabel!
+    @IBOutlet weak var discountLabel: UILabel!
+    
+    func configure(_ viewModel: HomeProductCellViewModel){
+//        imageView.image =
+        imageView.layer.cornerRadius = 5
+        imageView.backgroundColor = .blue
+        titleLabel.text = viewModel.title
+        reasonDiscountLabel.text = viewModel.reasonDiscountString
+        originalLabel.attributedText = NSMutableAttributedString(string: viewModel.originalPriceString, attributes: [NSAttributedString.Key.strikethroughStyle: NSUnderlineStyle.single.rawValue])
+        discountLabel.text = viewModel.discountPriceString
+        
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
[FEAT] 홈화면 가로 스크롤 아이템 제작 #7

## ✨ 이슈 내용
<!-- 이슈에 대한 설명을 적어주세요 -->
1. 취소한을 코드로 구현하는 방법
2. Section을 분리하는 방법
3. SwiftUI처럼 Preview 사용하는 방법

## ‼️ TODO
<!-- 해결하지 못했거나 추후 해야할 일에 대한 설명을 적어주세요 -->

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->
1. 취소한을 코드로 구현하는 방법
<img width="1153" alt="스크린샷 2025-04-01 오후 3 14 36" src="https://github.com/user-attachments/assets/9eda6cd9-431c-4ad4-a30f-38ad9050ee69" />

2. Section을 분리하는 방법
<img src="https://github.com/user-attachments/assets/293ce055-0cd0-4678-985a-695cc9163a68" width="200" height="300"/>
<img width="991" alt="스크린샷 2025-04-01 오후 3 50 14" src="https://github.com/user-attachments/assets/24d3f67a-a50d-4179-9498-dd409f9db1b9" />
<img width="987" alt="스크린샷 2025-04-01 오후 3 50 21" src="https://github.com/user-attachments/assets/feec09ab-f6ff-4fe1-94e7-4457b4c043a3" />

3. SwiftUI처럼 Preview 사용하는 방법
<img width="1285" alt="스크린샷 2025-04-01 오후 3 39 05" src="https://github.com/user-attachments/assets/64b6d915-68fe-463f-87a3-980cd706b6c1" />

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
### 1. `ViewModel에 따른 Section 분리` 정리
- `UICollectionViewDiffableDataSource<Section, AnyHashable>`를 통해  각 셀마다 다른 `ViewModel` 타입을 활용할 수 있도록 구성했습니다.

- 섹션 분리를 위해 `Section` enum을 정의하고, `Snapshot`에 섹션과 아이템을 순서대로 추가함으로써 `switch Section(rawValue: indexPath.section)`로 섹션 분기를 처리하고 있습니다.

- 셀 바인딩 시 각 섹션에 맞는 셀(`HomeBannerCell`, `HomeProductCell`)과 `ViewModel` (`HomeBannerCellViewModel`, `HomeProductCellViewModel`)을 타입 캐스팅하여 `configure(_:)` 메서드를 호출하는 방식으로 구성했습니다.

- `UICollectionViewCompositionalLayout`에서도 `Section` enum을 활용해  
  **섹션별로 다른 레이아웃을 정의**하였습니다:
  - `banner` 섹션은 `.groupPaging`을 적용한 가로 슬라이드형 배너
  - `horizontalProductItem` 섹션은 `.continuous` 스크롤을 사용하는 카드 리스트 형식  (`contentInsets`, `interGroupSpacing` 등 레이아웃 간격도 설정)