### PR TITLE
[REFACTOR] NetworkService 리펙토링

### DIFF
--- a/Cproject/Network/NetworkService.swift
+++ b/Cproject/Network/NetworkService.swift
@@ -7,20 +7,47 @@
 
 import Foundation
 
+enum NetworkError: Error {
+    case urlError
+    case responseError
+    case decodeError
+    case serverError(statusCode: Int)
+    case unknownError
+}
+
 class NetworkService {
     static let shared: NetworkService = NetworkService()
     
-    func getHomeData() async throws -> HomeResponse{
-        let urlString = "https://my-json-server.typicode.com/JeaSungLEE/JsonAPIFastCampus/db"
-        guard let url = URL(string: urlString) else { throw URLError(.badURL)}
+    private let hostURL: String = "https://my-json-server.typicode.com/JeaSungLEE/JsonAPIFastCampus"
+    
+    private func createdURL(withPath path: String) throws -> URL {
+        let urlString = "\(hostURL)\(path)"
+        guard let url = URL(string: urlString) else { throw NetworkError.urlError}
         
+        return url
+    }
+    
+    private func fetchData(from url: URL) async throws -> Data {
         let (data, response) = try await URLSession.shared.data(from: url)
-        guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
-            throw URLError(.badServerResponse)
+        guard let httpResponse = response as? HTTPURLResponse else { throw NetworkError.responseError }
+        
+        switch httpResponse.statusCode {
+        case 200...299:
+            return data
+        default:
+            throw NetworkError.serverError(statusCode: httpResponse.statusCode)
         }
+    }
+    
+    func getHomeData() async throws -> HomeResponse{
+        let url = try createdURL(withPath: "/db")
+        let data = try await fetchData(from: url)
         
-        let decodeData = try JSONDecoder().decode(HomeResponse.self, from: data)
-        return decodeData
-        
+        do {
+            let decodeData = try JSONDecoder().decode(HomeResponse.self, from: data)
+            return decodeData
+        } catch {
+            throw NetworkError.decodeError
+        }
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
[REFACTOR] NetworkService 리펙토링 #13

## ✨ 이슈 내용
<!-- 이슈에 대한 설명을 적어주세요 -->
1. NetworkService 리펙토링

## ‼️ TODO
<!-- 해결하지 못했거나 추후 해야할 일에 대한 설명을 적어주세요 -->

## 📸 코드 및 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->
1. NetworkError 추가 및 코드 분리
```swift
enum NetworkError: Error {
    case urlError
    case responseError
    case decodeError
    case serverError(statusCode: Int)
    case unknownError
}

class NetworkService {
    static let shared: NetworkService = NetworkService()
    
    private let hostURL: String = "https://my-json-server.typicode.com/JeaSungLEE/JsonAPIFastCampus"
    
    private func createdURL(withPath path: String) throws -> URL {
        let urlString = "\(hostURL)\(path)"
        guard let url = URL(string: urlString) else { throw NetworkError.urlError}
        
        return url
    }
    
    private func fetchData(from url: URL) async throws -> Data {
        let (data, response) = try await URLSession.shared.data(from: url)
        guard let httpResponse = response as? HTTPURLResponse else { throw NetworkError.responseError }
        
        switch httpResponse.statusCode {
        case 200...299:
            return data
        default:
            throw NetworkError.serverError(statusCode: httpResponse.statusCode)
        }
    }
    
    func getHomeData() async throws -> HomeResponse{
        let url = try createdURL(withPath: "/db")
        let data = try await fetchData(from: url)
        
        do {
            let decodeData = try JSONDecoder().decode(HomeResponse.self, from: data)
            return decodeData
        } catch {
            throw NetworkError.decodeError
        }
    }
}
```

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->

1. **에러 핸들링을 위한 `NetworkError` 열거형 추가**
   - `urlError`, `responseError`, `decodeError`, `serverError`, `unknownError` 등으로  
     주요 오류 케이스를 정의하여 가독성과 디버깅 효율을 높였습니다.

2. **기능 단위로 명확하게 함수 분리**
   - `createdURL(withPath:)`: URL 문자열 생성을 책임지는 함수로, URL 생성 실패 시 명확한 에러 반환.
   - `fetchData(from:)`: 공통 네트워크 요청 함수로, 응답 상태 코드 체크 및 데이터 반환 역할.
   - `getHomeData()`: 실제 API 호출 메서드로, 내부에서 `URL 생성 → 데이터 요청 → 디코딩`까지 수행하며  
     모든 과정에서 발생 가능한 오류를 명시적으로 처리하도록 설계했습니다.

3. **상태 코드 기반 에러 처리 도입**
   - HTTP 응답 코드가 200~299 범위가 아닐 경우, `.serverError(statusCode:)`로 세분화된 오류를 발생시켜  
     추후 사용자 피드백 및 로깅 처리에 용이하도록 구성했습니다.
