### PR TITLE
[FEAT] 홈 화면 버튼 구현

### DIFF
--- a/Cproject/DesignSource/CPImage/CPImage.swift
+++ b/Cproject/DesignSource/CPImage/CPImage.swift
@@ -8,6 +8,10 @@
 import UIKit
 
 enum CPImage {
+    
+    static var btnComplete: UIImage = UIImage(resource: .btnComplete)
+    static var btnActivate: UIImage = UIImage(resource: .btnActivate)
+    
     static var topBtn: UIImage = UIImage(resource: .topBtn)
     static var home: UIImage = UIImage(resource: .home)
     static var left: UIImage = UIImage(resource: .left)

--- a/Cproject/Feature/Home/Home.storyboard
+++ b/Cproject/Feature/Home/Home.storyboard
@@ -29,14 +29,14 @@
                                 </collectionViewFlowLayout>
                                 <cells>
                                     <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="HomeBannerCell" id="vY9-XQ-E9A" customClass="HomeBannerCell" customModule="Cproject" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="0.0" width="393" height="229"/>
+                                        <rect key="frame" x="0.0" y="27" width="214" height="137"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="QP9-Pn-uXg">
-                                            <rect key="frame" x="0.0" y="0.0" width="393" height="229"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="214" height="137"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="JwU-hc-BqW">
-                                                    <rect key="frame" x="0.0" y="0.0" width="393" height="229"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="214" height="137"/>
                                                 </imageView>
                                             </subviews>
                                             <constraints>
@@ -46,56 +46,56 @@
                                                 <constraint firstAttribute="bottom" secondItem="JwU-hc-BqW" secondAttribute="bottom" id="n7F-hY-GZI"/>
                                             </constraints>
                                         </collectionViewCellContentView>
-                                        <size key="customSize" width="393" height="229"/>
+                                        <size key="customSize" width="214" height="137"/>
                                         <connections>
                                             <outlet property="imageView" destination="JwU-hc-BqW" id="fig-Tu-hVr"/>
                                         </connections>
                                     </collectionViewCell>
                                     <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="HomeProductCell" id="qXh-U1-YLt" customClass="HomeProductCell" customModule="Cproject" customModuleProvider="target">
-                                        <rect key="frame" x="76.666666666666671" y="239" width="240" height="331.33333333333326"/>
+                                        <rect key="frame" x="292" y="0.0" width="101" height="191"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="62o-hi-JUN">
-                                            <rect key="frame" x="0.0" y="0.0" width="240" height="331.33333333333326"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="101" height="191"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="spr-P1-83x">
-                                                    <rect key="frame" x="0.0" y="0.0" width="240" height="331.33333333333331"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="101" height="191"/>
                                                     <subviews>
                                                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Ce0-jy-x1G">
-                                                            <rect key="frame" x="0.0" y="0.0" width="240" height="240"/>
+                                                            <rect key="frame" x="0.0" y="0.0" width="101" height="101"/>
                                                             <constraints>
                                                                 <constraint firstAttribute="width" secondItem="Ce0-jy-x1G" secondAttribute="height" multiplier="1:1" id="CaB-Gl-7em"/>
                                                             </constraints>
                                                         </imageView>
                                                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="13" translatesAutoresizingMaskIntoConstraints="NO" id="wUG-Vd-c4s">
-                                                            <rect key="frame" x="0.0" y="252.00000000000003" width="240" height="79.333333333333343"/>
+                                                            <rect key="frame" x="0.0" y="113" width="101" height="78"/>
                                                             <subviews>
-                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="t7x-tp-7nm">
-                                                                    <rect key="frame" x="0.0" y="0.0" width="240" height="17"/>
+                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="t7x-tp-7nm">
+                                                                    <rect key="frame" x="0.0" y="0.0" width="101" height="15.666666666666666"/>
                                                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                                     <color key="textColor" name="bk"/>
                                                                     <nil key="highlightedColor"/>
                                                                 </label>
-                                                                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="G48-1k-8Pz">
-                                                                    <rect key="frame" x="0.0" y="30.000000000000004" width="240" height="49.333333333333343"/>
+                                                                <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" axis="vertical" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="G48-1k-8Pz">
+                                                                    <rect key="frame" x="0.0" y="28.666666666666661" width="101" height="49.333333333333343"/>
                                                                     <subviews>
-                                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="h61-xq-fJf">
-                                                                            <rect key="frame" x="0.0" y="0.0" width="240" height="12"/>
+                                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="h61-xq-fJf">
+                                                                            <rect key="frame" x="0.0" y="0.0" width="101" height="12"/>
                                                                             <fontDescription key="fontDescription" type="system" pointSize="10"/>
                                                                             <color key="textColor" name="key-color-red-2"/>
                                                                             <nil key="highlightedColor"/>
                                                                         </label>
-                                                                        <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="1" translatesAutoresizingMaskIntoConstraints="NO" id="szm-dV-P2e">
-                                                                            <rect key="frame" x="0.0" y="17.000000000000004" width="240" height="32.333333333333343"/>
+                                                                        <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" axis="vertical" spacing="1" translatesAutoresizingMaskIntoConstraints="NO" id="szm-dV-P2e">
+                                                                            <rect key="frame" x="0.0" y="17.000000000000004" width="101" height="32.333333333333343"/>
                                                                             <subviews>
-                                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ldy-9u-raW">
-                                                                                    <rect key="frame" x="0.0" y="0.0" width="240" height="14.333333333333334"/>
+                                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ldy-9u-raW">
+                                                                                    <rect key="frame" x="0.0" y="0.0" width="101" height="14.333333333333334"/>
                                                                                     <fontDescription key="fontDescription" type="system" weight="medium" pointSize="12"/>
                                                                                     <color key="textColor" name="gray-4"/>
                                                                                     <nil key="highlightedColor"/>
                                                                                 </label>
-                                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Jjw-zh-v6W">
-                                                                                    <rect key="frame" x="0.0" y="15.333333333333314" width="240" height="17"/>
+                                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Jjw-zh-v6W">
+                                                                                    <rect key="frame" x="0.0" y="15.333333333333343" width="101" height="17"/>
                                                                                     <fontDescription key="fontDescription" type="boldSystem" pointSize="14"/>
                                                                                     <color key="textColor" name="key-color-red"/>
                                                                                     <nil key="highlightedColor"/>
@@ -116,12 +116,48 @@
                                                 <constraint firstItem="spr-P1-83x" firstAttribute="top" secondItem="62o-hi-JUN" secondAttribute="top" id="fVe-qY-DLj"/>
                                             </constraints>
                                         </collectionViewCellContentView>
+                                        <size key="customSize" width="101" height="191"/>
                                         <connections>
                                             <outlet property="discountLabel" destination="Jjw-zh-v6W" id="C4n-qi-qvF"/>
                                             <outlet property="imageView" destination="Ce0-jy-x1G" id="396-Ki-YF0"/>
                                             <outlet property="originalLabel" destination="Ldy-9u-raW" id="8LM-rP-hZl"/>
                                             <outlet property="reasonDiscountLabel" destination="h61-xq-fJf" id="3KM-aT-HBq"/>
                                             <outlet property="titleLabel" destination="t7x-tp-7nm" id="F1K-t3-Q7a"/>
+                                        </connections>
+                                    </collectionViewCell>
+                                    <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="HomeSeparatorLineCell" id="ZuO-DK-13B" customClass="HomeSeparatorLineCell" customModule="Cproject" customModuleProvider="target">
+                                        <rect key="frame" x="0.0" y="201" width="393" height="229"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="DZR-bn-Yff">
+                                            <rect key="frame" x="0.0" y="0.0" width="393" height="229"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                        </collectionViewCellContentView>
+                                    </collectionViewCell>
+                                    <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="HomeCouponBtnCell" id="wJJ-d0-qqU" customClass="HomeCouponBtnCell" customModule="Cproject" customModuleProvider="target">
+                                        <rect key="frame" x="0.0" y="440" width="24" height="14"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="dLq-ru-oBc">
+                                            <rect key="frame" x="0.0" y="0.0" width="24" height="14"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="MCc-R6-fTW">
+                                                    <rect key="frame" x="0.0" y="0.0" width="24" height="14"/>
+                                                    <state key="normal" title="Button"/>
+                                                    <buttonConfiguration key="configuration" style="plain"/>
+                                                    <connections>
+                                                        <action selector="didTapCouponButton:" destination="wJJ-d0-qqU" eventType="touchUpInside" id="UrG-BS-7WE"/>
+                                                    </connections>
+                                                </button>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstAttribute="bottom" secondItem="MCc-R6-fTW" secondAttribute="bottom" id="6wX-1X-2gi"/>
+                                                <constraint firstAttribute="trailing" secondItem="MCc-R6-fTW" secondAttribute="trailing" id="YIZ-ln-XTd"/>
+                                                <constraint firstItem="MCc-R6-fTW" firstAttribute="top" secondItem="dLq-ru-oBc" secondAttribute="top" id="gtQ-iN-sbo"/>
+                                                <constraint firstItem="MCc-R6-fTW" firstAttribute="leading" secondItem="dLq-ru-oBc" secondAttribute="leading" id="q4O-z1-4i1"/>
+                                            </constraints>
+                                        </collectionViewCellContentView>
+                                        <connections>
+                                            <outlet property="couponButton" destination="MCc-R6-fTW" id="cSQ-lT-UB9"/>
                                         </connections>
                                     </collectionViewCell>
                                 </cells>

--- a/Cproject/Feature/Home/View/HomeBannerCell.swift
+++ b/Cproject/Feature/Home/View/HomeBannerCell.swift
@@ -12,9 +12,9 @@ struct HomeBannerCellViewModel: Hashable{
     let bannerImageUrl: String
 }
 
-class HomeBannerCell: UICollectionViewCell {
-    
-    @IBOutlet weak var imageView: UIImageView!
+final class HomeBannerCell: UICollectionViewCell {
+    static let reusableId: String = "HomeBannerCell"
+    @IBOutlet private weak var imageView: UIImageView!
     
     func configure(_ viewModel: HomeBannerCellViewModel){
         imageView.kf.setImage(with: URL(string: viewModel.bannerImageUrl))

--- a/Cproject/Feature/Home/View/HomeCouponBtnCell.swift
+++ b/Cproject/Feature/Home/View/HomeCouponBtnCell.swift
@@ -1,0 +1,63 @@
+//
+//  HomeCouponBtnCell.swift
+//  Cproject
+//
+//  Created by wodnd on 4/7/25.
+//
+
+import UIKit
+import Combine
+
+struct HomeCouponBtnViewModel: Hashable {
+    enum CouponState {
+        case enable
+        case disable
+    }
+    
+    var state: CouponState
+}
+
+final class HomeCouponBtnCell: UICollectionViewCell {
+    static let reusableId: String = "HomeCouponBtnCell"
+    
+    private weak  var didTapCouponDownload: PassthroughSubject<Void, Never>?
+    
+    @IBOutlet weak var couponButton: UIButton! {
+        didSet{
+            couponButton.setImage(CPImage.btnActivate, for: .normal)
+            couponButton.setImage(CPImage.btnComplete, for: .disabled)
+        }
+    }
+    
+    func configure(_ viewModel: HomeCouponBtnViewModel, _ didTapCouponDownload: PassthroughSubject<Void, Never>?) {
+        self.didTapCouponDownload = didTapCouponDownload
+        
+        couponButton.isEnabled = switch viewModel.state {
+        case .enable:
+            true
+        case .disable:
+            false
+        }
+    }
+    @IBAction func didTapCouponButton(_ sender: Any) {
+        didTapCouponDownload?.send()
+    }
+}
+
+
+extension HomeCouponBtnCell {
+    static func couponBtnLayout() -> NSCollectionLayoutSection {
+        let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .fractionalHeight(1))
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+        
+        let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .absolute(37))
+        let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item])
+        
+        let section = NSCollectionLayoutSection(group: group)
+        section.orthogonalScrollingBehavior = .none
+        section.contentInsets = .init(top: 28, leading: 22, bottom: 0, trailing: 22)
+        
+        return section
+        
+    }
+}

--- a/Cproject/Feature/Home/View/HomeProductCell.swift
+++ b/Cproject/Feature/Home/View/HomeProductCell.swift
@@ -16,13 +16,14 @@ struct HomeProductCellViewModel: Hashable {
     let discountPriceString: String
 }
 
-class HomeProductCell: UICollectionViewCell {
+final class HomeProductCell: UICollectionViewCell {
+    static let reusableId: String = "HomeProductCell"
     
-    @IBOutlet weak var imageView: UIImageView!
-    @IBOutlet weak var titleLabel: UILabel!
-    @IBOutlet weak var reasonDiscountLabel: UILabel!
-    @IBOutlet weak var originalLabel: UILabel!
-    @IBOutlet weak var discountLabel: UILabel!
+    @IBOutlet private weak var imageView: UIImageView!
+    @IBOutlet private weak var titleLabel: UILabel!
+    @IBOutlet private weak var reasonDiscountLabel: UILabel!
+    @IBOutlet private weak var originalLabel: UILabel!
+    @IBOutlet private weak var discountLabel: UILabel!
     
     func configure(_ viewModel: HomeProductCellViewModel){
         imageView.kf.setImage(with: URL(string: viewModel.imageUlrString))
@@ -47,7 +48,7 @@ extension HomeProductCell {
         let section = NSCollectionLayoutSection(group: group)
         section.orthogonalScrollingBehavior = .continuous
         
-        section.contentInsets = .init(top: 20, leading: 33, bottom: 0, trailing: 33)
+        section.contentInsets = .init(top: 40, leading: 33, bottom: 0, trailing: 33)
         section.interGroupSpacing = 14
         
         return section
@@ -63,8 +64,8 @@ extension HomeProductCell {
         
         let section = NSCollectionLayoutSection(group: group)
         section.orthogonalScrollingBehavior = .none
-        
-        section.contentInsets = .init(top: 20, leading: 19 - 2.5, bottom: 0, trailing: 19 - 2.5)
+        section.interGroupSpacing = 10
+        section.contentInsets = .init(top: 40, leading: 19 - 2.5, bottom: 0, trailing: 19 - 2.5)
         
         return section
         

--- a/Cproject/Feature/Home/View/HomeSeparatorLineCell.swift
+++ b/Cproject/Feature/Home/View/HomeSeparatorLineCell.swift
@@ -1,0 +1,37 @@
+//
+//  HomeSpearateLineCell.swift
+//  Cproject
+//
+//  Created by wodnd on 4/7/25.
+//
+
+import UIKit
+
+struct HomeSeparatorLineCellViewModel: Hashable {
+    
+}
+
+final class HomeSeparatorLineCell: UICollectionViewCell {
+    static let reusableId: String = "HomeSeparatorLineCell"
+    
+    func configure(_ viewModel: HomeSeparatorLineCellViewModel){
+        contentView.backgroundColor = CPColor.gray1
+    }
+}
+
+extension HomeSeparatorLineCell {
+    static func separatorLineLayout() -> NSCollectionLayoutSection {
+        let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .fractionalHeight(1))
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+        
+        let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .absolute(11))
+        let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item])
+        
+        let section = NSCollectionLayoutSection(group: group)
+        section.orthogonalScrollingBehavior = .none
+        section.contentInsets = .init(top: 13, leading: 0, bottom: 0, trailing: 0)
+        
+        return section
+        
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
[FEAT] 홈 화면 버튼 구현 #15

## ✨ 이슈 내용
<!-- 이슈에 대한 설명을 적어주세요 -->
1. 홈 화면 버튼 구현
2. final, private 키워드 습관화
3. 긴 제네릭 타입을 typealias로 간결화

## ‼️ TODO
<!-- 해결하지 못했거나 추후 해야할 일에 대한 설명을 적어주세요 -->

## 📸 코드 및 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->
## ✅ 쿠폰 버튼 기능 흐름 설명 (MVI 기반 구조)
<img src="https://github.com/user-attachments/assets/4a85b225-8f64-4239-ae2a-983065e1335a" width="300" height="100"/>

1. **Cell에서 버튼 터치 감지**
HomeCouponBtnCell에 있는 쿠폰 버튼이 터치되면, PassthroughSubject를 통해 버튼 클릭 이벤트가 신호(signal) 로 방출됨.
```swift
   @IBAction func didTapCouponButton(_ sender: Any) {
       didTapCouponDownload?.send()
   }
```

2. **ViewController에서 버튼 클릭 이벤트 수신**
ViewController는 didTapCouponDownload를 구독 중이기 때문에, 버튼이 눌리면 .didTapCouponButton 액션을 process로 ViewModel에 전달함.
```swift
   case .didTapCouponButton:
    downloadCoupon()
```

3. **ViewModel이 액션 처리 - process(.didTapCouponButton)**
ViewModel의 process 메서드에서 .didTapCouponButton에 대한 분기에서 내부적으로 downloadCoupon() 메서드를 호출함.
```swift
   didTapCouponDownload
    .receive(on: DispatchQueue.main)
    .sink { [weak self] _ in
        self?.viewModel.process(.didTapCouponButton)
    }.store(in: &cancellables)
```

4. **UserDefaults에 상태 저장 및 상태 업데이트**
쿠폰을 다운받았다는 사실을 UserDefaults에 저장하고, 다시 process(.loadCoupon)을 호출해서 저장된 상태를 기반으로 UI 업데이트 트리거를 발생시킴.
```swift
   private func downloadCoupon() {
    UserDefaults.standard.set(true, forKey: couponKey)
    process(.loadCoupon)
}
```

5. **쿠폰 상태 로드**
쿠폰을 받았는지에 대한 Bool 값을 UserDefaults에서 가져오고, .getCouponSuccess 액션으로 다시 process로 전달.
```swift
   private func loadCoupon() {
    let couponState: Bool = UserDefaults.standard.bool(forKey: couponKey)
    process(.getCouponSuccess(couponState))
}
```

6. **ViewModel에서 상태 변환 처리**
쿠폰을 이미 받았다면 버튼을 .disable, 안 받았다면 .enable로 상태 설정. 이로 인해 @Published var collectionViewModels 값이 변경되고 → Combine이 이를 감지함.
```swift
   @MainActor
private func transformCoupon(_ couponState: Bool) async {
    state.collectionViewModels.couponSate = [.init(state: couponState ? .disable : .enable)]
}
```

7. **ViewController에서 UI 갱신**
ViewModel의 상태가 바뀌면, ViewController는 새로운 snapshot을 적용하여 👉 쿠폰 버튼의 UI 상태가 실시간으로 갱신됨 (활성화 → 비활성화).
```swift
   viewModel.state.$collectionViewModels
    .receive(on: DispatchQueue.main)
    .sink { [weak self] _ in
        self?.applySnapShot()
    }.store(in: &cancellables)
```

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
1. **`final` 및 `private` 키워드 습관화**
   - `final`은 클래스의 상속을 방지하며 컴파일 최적화에 유리합니다.
   - `private`은 외부 접근을 막아 모듈화 및 캡슐화를 강화합니다.
   - 클래스에는 `final`, 속성과 함수에는 `private` 키워드를 명시하여 **의도하지 않은 접근과 상속을 방지**하고 있습니다.

2. **긴 제네릭 타입을 `typealias`로 간결화**
   - `UICollectionViewDiffableDataSource<Section, AnyHashable>`  
     → `typealias DataSource`
   - `NSDiffableDataSourceSnapshot<Section, AnyHashable>`  
     → `typealias Snapshot`
   - **가독성과 생산성** 향상에 기여하며, 코드의 반복을 줄였습니다.
