### PR TITLE
[FEAT] 홈 화면 가로 배너 구현

### DIFF
--- a/Cproject/Feature/Home/Home.storyboard
+++ b/Cproject/Feature/Home/Home.storyboard
@@ -23,13 +23,13 @@
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="vXs-AM-ReB">
                                     <size key="itemSize" width="393" height="229"/>
-                                    <size key="headerReferenceSize" width="0.0" height="0.0"/>
+                                    <size key="headerReferenceSize" width="50" height="83"/>
                                     <size key="footerReferenceSize" width="0.0" height="0.0"/>
                                     <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                                 </collectionViewFlowLayout>
                                 <cells>
                                     <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="HomeBannerCell" id="vY9-XQ-E9A" customClass="HomeBannerCell" customModule="Cproject" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="27" width="214" height="137"/>
+                                        <rect key="frame" x="0.0" y="110" width="214" height="137"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="QP9-Pn-uXg">
                                             <rect key="frame" x="0.0" y="0.0" width="214" height="137"/>
@@ -52,7 +52,7 @@
                                         </connections>
                                     </collectionViewCell>
                                     <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="HomeProductCell" id="qXh-U1-YLt" customClass="HomeProductCell" customModule="Cproject" customModuleProvider="target">
-                                        <rect key="frame" x="292" y="0.0" width="101" height="191"/>
+                                        <rect key="frame" x="292" y="83" width="101" height="191"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="62o-hi-JUN">
                                             <rect key="frame" x="0.0" y="0.0" width="101" height="191"/>
@@ -126,7 +126,7 @@
                                         </connections>
                                     </collectionViewCell>
                                     <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="HomeSeparatorLineCell" id="ZuO-DK-13B" customClass="HomeSeparatorLineCell" customModule="Cproject" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="201" width="393" height="229"/>
+                                        <rect key="frame" x="0.0" y="284" width="393" height="229"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="DZR-bn-Yff">
                                             <rect key="frame" x="0.0" y="0.0" width="393" height="229"/>
@@ -134,7 +134,7 @@
                                         </collectionViewCellContentView>
                                     </collectionViewCell>
                                     <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="HomeCouponBtnCell" id="wJJ-d0-qqU" customClass="HomeCouponBtnCell" customModule="Cproject" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="440" width="24" height="14"/>
+                                        <rect key="frame" x="184.66666666666666" y="523" width="24" height="14"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="dLq-ru-oBc">
                                             <rect key="frame" x="0.0" y="0.0" width="24" height="14"/>
@@ -160,7 +160,50 @@
                                             <outlet property="couponButton" destination="MCc-R6-fTW" id="cSQ-lT-UB9"/>
                                         </connections>
                                     </collectionViewCell>
+                                    <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="HomeThemeCell" id="QVx-Vu-F0s" customClass="HomeThemeCell" customModule="Cproject" customModuleProvider="target">
+                                        <rect key="frame" x="0.0" y="547" width="393" height="229"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="Pvj-vj-rKW">
+                                            <rect key="frame" x="0.0" y="0.0" width="393" height="229"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="2uA-ah-cjt">
+                                                    <rect key="frame" x="0.0" y="0.0" width="393" height="229"/>
+                                                </imageView>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstAttribute="trailing" secondItem="2uA-ah-cjt" secondAttribute="trailing" id="D4Q-ku-0MW"/>
+                                                <constraint firstAttribute="bottom" secondItem="2uA-ah-cjt" secondAttribute="bottom" id="aBP-SU-5Gh"/>
+                                                <constraint firstItem="2uA-ah-cjt" firstAttribute="leading" secondItem="Pvj-vj-rKW" secondAttribute="leading" id="fi5-4K-w4q"/>
+                                                <constraint firstItem="2uA-ah-cjt" firstAttribute="top" secondItem="Pvj-vj-rKW" secondAttribute="top" id="lJx-t4-pD9"/>
+                                            </constraints>
+                                        </collectionViewCellContentView>
+                                        <connections>
+                                            <outlet property="imageView" destination="2uA-ah-cjt" id="nD7-ej-uYi"/>
+                                        </connections>
+                                    </collectionViewCell>
                                 </cells>
+                                <collectionReusableView key="sectionHeaderView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="HomeThemeHeaderView" id="bP7-8N-1An" customClass="HomeThemeHeaderView" customModule="Cproject" customModuleProvider="target">
+                                    <rect key="frame" x="0.0" y="0.0" width="393" height="83"/>
+                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                    <subviews>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Atg-yI-XuI">
+                                            <rect key="frame" x="30" y="23" width="333" height="60"/>
+                                            <fontDescription key="fontDescription" type="boldSystem" pointSize="16"/>
+                                            <nil key="textColor"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                    </subviews>
+                                    <constraints>
+                                        <constraint firstItem="Atg-yI-XuI" firstAttribute="leading" secondItem="bP7-8N-1An" secondAttribute="leading" constant="30" id="VfB-pt-8MF"/>
+                                        <constraint firstAttribute="trailing" secondItem="Atg-yI-XuI" secondAttribute="trailing" constant="30" id="Y1D-zP-7iF"/>
+                                        <constraint firstAttribute="bottom" secondItem="Atg-yI-XuI" secondAttribute="bottom" id="ahS-l8-XJO"/>
+                                        <constraint firstItem="Atg-yI-XuI" firstAttribute="top" secondItem="bP7-8N-1An" secondAttribute="top" constant="23" id="xdA-nS-B62"/>
+                                    </constraints>
+                                    <connections>
+                                        <outlet property="headerLabel" destination="Atg-yI-XuI" id="RKq-Gz-LfQ"/>
+                                    </connections>
+                                </collectionReusableView>
                             </collectionView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>

--- a/Cproject/Feature/Home/HomeViewController.swift
+++ b/Cproject/Feature/Home/HomeViewController.swift
@@ -31,6 +31,7 @@ final class HomeViewController: UIViewController {
         case couponBtn
         case verticalProductItem
         case separteLine2
+        case theme
     }
     
     override func viewDidLoad() {
@@ -57,6 +58,8 @@ final class HomeViewController: UIViewController {
                 return HomeProductCell.verticalProductItemLayout()
             case .separteLine1, .separteLine2:
                 return HomeSeparatorLineCell.separatorLineLayout()
+            case .theme:
+                return HomeThemeCell.themeLayout()
             case .none: return nil
             }
         }
@@ -75,7 +78,7 @@ final class HomeViewController: UIViewController {
     }
     
     private func setDataSource() -> DataSource {
-        return UICollectionViewDiffableDataSource(collectionView: collectionView, cellProvider: { [weak self] collectionView, indexPath, viewModel in
+        let dataSource: DataSource = UICollectionViewDiffableDataSource(collectionView: collectionView, cellProvider: { [weak self] collectionView, indexPath, viewModel in
             
             switch self?.currentSection[indexPath.section]{
             case .banner:
@@ -86,10 +89,22 @@ final class HomeViewController: UIViewController {
                 return self?.couponCell(collectionView, indexPath, viewModel)
             case .separteLine1, .separteLine2:
                 return self?.separteCell(collectionView, indexPath, viewModel)
+            case .theme:
+                return self?.themeCell(collectionView, indexPath, viewModel)
             case .none:
                 return .init()
             }
         })
+        
+        dataSource.supplementaryViewProvider = { collectionView, kind, indexPath in
+            guard kind == UICollectionView.elementKindSectionHeader, let viewModel = self.viewModel.state.collectionViewModels.themeViewModels?.header else { return nil }
+            
+            let headerView = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: HomeThemeHeaderView.resuableId, for: indexPath) as? HomeThemeHeaderView
+            
+            headerView?.configure(viewModel)
+            return headerView
+        }
+        return dataSource
     }
     
     private func applySnapShot() {
@@ -116,6 +131,14 @@ final class HomeViewController: UIViewController {
         if let verticalProductViewModels = viewModel.state.collectionViewModels.verticalProductViewModels{
             snapshot.appendSections([.verticalProductItem])
             snapshot.appendItems(verticalProductViewModels, toSection: .verticalProductItem)
+        }
+        
+        if let themeViewModels = viewModel.state.collectionViewModels.themeViewModels?.items{
+            snapshot.appendSections([.separteLine2])
+            snapshot.appendItems(viewModel.state.collectionViewModels.separateLine2ViewModels, toSection: .separteLine2)
+            
+            snapshot.appendSections([.theme])
+            snapshot.appendItems(themeViewModels, toSection: .theme)
         }
         
         dataSource.apply(snapshot)
@@ -170,8 +193,18 @@ final class HomeViewController: UIViewController {
         cell.configure(viewModel)
         return cell
     }
+    
+    private func themeCell(_ collectionView: UICollectionView, _ indexPath: IndexPath, _ viewModel: AnyHashable) -> UICollectionViewCell {
+       
+        guard let viewModel = viewModel as? HomeThemeCellViewModel,
+              let cell: HomeThemeCell = collectionView.dequeueReusableCell(withReuseIdentifier: HomeThemeCell.resuableId, for: indexPath) as? HomeThemeCell else { return .init() }
+        
+        cell.configure(viewModel)
+        return cell
+    }
 }
 
 #Preview{
     UIStoryboard(name: "Home", bundle: nil).instantiateViewController(withIdentifier: "HomeViewController") as! HomeViewController
 }
+ 

--- a/Cproject/Feature/Home/HomeViewModel.swift
+++ b/Cproject/Feature/Home/HomeViewModel.swift
@@ -26,6 +26,7 @@ final class HomeViewModel{
             var couponSate: [HomeCouponBtnViewModel]?
             var separateLine1ViewModels: [HomeSeparatorLineCellViewModel] = [HomeSeparatorLineCellViewModel()]
             var separateLine2ViewModels: [HomeSeparatorLineCellViewModel] = [HomeSeparatorLineCellViewModel()]
+            var themeViewModels: (header: HomeThemeHeaderViewModel, items: [HomeThemeCellViewModel])?
         }
         
         @Published var collectionViewModels: CollectionViewModels = CollectionViewModels()
@@ -78,6 +79,7 @@ extension HomeViewModel {
         Task { await transformBanner(response) }
         Task{ await transformHorizontalProduct(response) }
         Task{ await transformVerticalProduct(response) }
+        Task{ await transformTheme(response) }
     }
     
     @MainActor
@@ -95,6 +97,15 @@ extension HomeViewModel {
     @MainActor
     private func transformVerticalProduct(_ response: HomeResponse) async {
         state.collectionViewModels.verticalProductViewModels = homeProductCellViewModel(response.verticalProducts)
+    }
+    
+    @MainActor
+    private func transformTheme(_ response: HomeResponse) async {
+        let items = response.themes.map({
+            HomeThemeCellViewModel(imageUrl: $0.imageUrl)
+        })
+        
+        state.collectionViewModels.themeViewModels = (HomeThemeHeaderViewModel(headerText: "테마관"), items)
     }
     
     private func homeProductCellViewModel(_ product: [Product]) -> [HomeProductCellViewModel] {

--- a/Cproject/Feature/Home/View/HomeThemeCell.swift
+++ b/Cproject/Feature/Home/View/HomeThemeCell.swift
@@ -1,0 +1,45 @@
+//
+//  HomeThemeCell.swift
+//  Cproject
+//
+//  Created by wodnd on 4/9/25.
+//
+
+import UIKit
+import Kingfisher
+
+struct HomeThemeCellViewModel: Hashable {
+    let imageUrl: String
+}
+
+final class HomeThemeCell: UICollectionViewCell {
+    static let resuableId: String = "HomeThemeCell"
+    
+    @IBOutlet weak var imageView: UIImageView!
+    
+    func configure(_ viewModel: HomeThemeCellViewModel) {
+        imageView.kf.setImage(with: URL(string: viewModel.imageUrl))
+    }
+}
+
+extension HomeThemeCell {
+    static func themeLayout() -> NSCollectionLayoutSection {
+        let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .fractionalHeight(1.0))
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+        
+        let groupFractionalWidth: CGFloat = 0.7
+        let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(groupFractionalWidth), heightDimension: .fractionalWidth((142/286) * groupFractionalWidth))
+        let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item])
+        
+        let section = NSCollectionLayoutSection(group: group)
+        section.orthogonalScrollingBehavior = .groupPagingCentered
+        section.interGroupSpacing = 16
+        section.contentInsets = .init(top: 35, leading: 0, bottom: 0, trailing: 0)
+        
+        let headerSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .absolute(65  ))
+        let header = NSCollectionLayoutBoundarySupplementaryItem(layoutSize: headerSize, elementKind: UICollectionView.elementKindSectionHeader, alignment: .top)
+        
+        section.boundarySupplementaryItems = [header]
+        return section
+    }
+}

--- a/Cproject/Feature/Home/View/HomeThemeHeaderView.swift
+++ b/Cproject/Feature/Home/View/HomeThemeHeaderView.swift
@@ -1,0 +1,21 @@
+//
+//  HomeThemeHeaderView.swift
+//  Cproject
+//
+//  Created by wodnd on 4/9/25.
+//
+
+import UIKit
+
+struct HomeThemeHeaderViewModel {
+    var headerText: String
+}
+
+final class HomeThemeHeaderView: UICollectionReusableView {
+    static let resuableId: String = "HomeThemeHeaderView"
+    
+    @IBOutlet weak var headerLabel: UILabel!
+    func configure(_ viewModel: HomeThemeHeaderViewModel) {
+        headerLabel.text = viewModel.headerText
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
[FEAT] 홈 화면 가로 배너 구현 #17

## ✨ 이슈 내용
<!-- 이슈에 대한 설명을 적어주세요 -->
1. 홈 화면 가로 배너 구현
2. UICollectionReusableView 활용하여 헤더 추가

## ‼️ TODO
<!-- 해결하지 못했거나 추후 해야할 일에 대한 설명을 적어주세요 -->
1. 카테고리 구현하기
<img src="https://github.com/user-attachments/assets/0a07d0f4-38a5-4326-8bc9-40df91c77074" width="300" height="150"/>

## 📸 코드 및 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->
<img src="https://github.com/user-attachments/assets/eb83ad0e-80be-4169-be9b-c1cdf3784d72" width="300" height="200"/>

1. 홈 화면 가로 배너 구현
```swift
extension HomeThemeCell {
    static func themeLayout() -> NSCollectionLayoutSection {
        let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .fractionalHeight(1.0))
        let item = NSCollectionLayoutItem(layoutSize: itemSize)
        
        let groupFractionalWidth: CGFloat = 0.7
        let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(groupFractionalWidth), heightDimension: .fractionalWidth((142/286) * groupFractionalWidth))
        let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item])
        
        let section = NSCollectionLayoutSection(group: group)
        section.orthogonalScrollingBehavior = .groupPagingCentered
        section.interGroupSpacing = 16
        section.contentInsets = .init(top: 35, leading: 0, bottom: 0, trailing: 0)
        
        let headerSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .absolute(65  ))
        let header = NSCollectionLayoutBoundarySupplementaryItem(layoutSize: headerSize, elementKind: UICollectionView.elementKindSectionHeader, alignment: .top)
        
        section.boundarySupplementaryItems = [header]
        return section
    }
}
```

2. UICollectionReusableView 활용하여 헤더 추가
```swift
dataSource.supplementaryViewProvider = { collectionView, kind, indexPath in
            guard kind == UICollectionView.elementKindSectionHeader, let viewModel = self.viewModel.state.collectionViewModels.themeViewModels?.header else { return nil }
            
            let headerView = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: HomeThemeHeaderView.resuableId, for: indexPath) as? HomeThemeHeaderView
            
            headerView?.configure(viewModel)
            return headerView
        }
        return dataSource
```


## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
1. **컬렉션 뷰 섹션 헤더(`UICollectionReusableView`) 적용**
   - 테마 영역에 헤더 타이틀을 표시하기 위해 `UICollectionReusableView`를 활용한 섹션 헤더를 추가했습니다.
   - `NSCollectionLayoutBoundarySupplementaryItem`을 통해 레이아웃 상단에 `.elementKindSectionHeader` 타입의 헤더를 배치하고,
     `supplementaryViewProvider`를 통해 `HomeThemeHeaderView`를 주입받아 데이터와 연결합니다.
   - ViewModel에서는 `themeViewModels`에 헤더 정보와 셀 데이터를 함께 담아 상태를 관리하고,  
     `snapshot`에 따라 헤더가 자동으로 갱신되도록 구현하였습니다.
   - 해당 헤더는 `themeLayout()` 내부에서 설정되며, 타이틀은 `"테마관"`으로 구성됩니다.