### PR TITLE
[BUGFIX] 제품상세 화면 Publishing 오류

### DIFF
--- a/Cproject.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Cproject.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "133a029fd563e7e12ab37e36c68e8245022922fd6408432d51ff1ac7fc84d7a1",
+  "originHash" : "e8c0c54b997208a1beb75ac017c19865235347eca8d481c126712652fa28a542",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",

--- a/Cproject/Feature/Detail/DetailViewModel.swift
+++ b/Cproject/Feature/Detail/DetailViewModel.swift
@@ -87,12 +87,10 @@ extension DetailViewModel {
 //    }
     private func loadData() {
         loadDataTask = Task {
-            defer {
-                process(.loading(false))
-            }
-
-            do {
+            await MainActor.run {
                 process(.loading(true))
+            }
+            do {
                 let db = Firestore.firestore()
                 let docRef = db.collection("ProductDetail").document("sample1")
 
@@ -104,6 +102,10 @@ extension DetailViewModel {
                 process(.getDataSucess(response))
             } catch {
                 process(.getDataFailure(error))
+            }
+            
+            await MainActor.run {
+                process(.loading(false))
             }
         }
     }


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
[BUGFIX] 제품상세 화면 Publishing 오류 #25

## ✨ 이슈 내용
<!-- 이슈에 대한 설명을 적어주세요 -->
1. 제품상세 화면 Publishing 오류

## 📸 코드 및 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->
1. 제품상세 화면 Publishing 오류
```swift
private func loadData() {
        loadDataTask = Task {
            await MainActor.run {
                process(.loading(true))
            }
            do {
                let db = Firestore.firestore()
                let docRef = db.collection("ProductDetail").document("sample1")

                let snapshot = try await docRef.getDocument()
                guard let response = try? snapshot.data(as: ProductDetailResponse.self) else {
                    throw NSError(domain: "DecodingError", code: -1)
                }

                process(.getDataSucess(response))
            } catch {
                process(.getDataFailure(error))
            }
            
            await MainActor.run {
                process(.loading(false))
            }
        }
    }
```

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
### 1. Publishing 오류 수정 방안
`@Published`로 선언된 state는 SwiftUI에서 UI에 직접 영향을 주기 때문에, **반드시 메인 스레드(MainActor)** 에서 변경해야 합니다.
