### PR TITLE
[REFACTOR] View를 VC로 부터 분리 작업

### DIFF
--- a/Cproject/Feature/Purchase/PurchaseViewController.swift
+++ b/Cproject/Feature/Purchase/PurchaseViewController.swift
@@ -11,136 +11,26 @@ import Combine
 final class PurchaseViewController: UIViewController {
     private var cancellables: Set<AnyCancellable> = []
     private var viewModel: PurchaseViewModel = PurchaseViewModel()
-    private var scrollViewConstraints: [NSLayoutConstraint]?
-    private var titleLabelConstraints: [NSLayoutConstraint]?
-    private var purchaseItemStackViewConstraints: [NSLayoutConstraint]?
-    private var purchaseButtonConstraints: [NSLayoutConstraint]?
+    private var rootView: PurchaseRootView = PurchaseRootView()
     
-    private var scrollView: UIScrollView = {
-        let scrollView: UIScrollView = UIScrollView()
-        scrollView.alwaysBounceVertical = true
-        scrollView.translatesAutoresizingMaskIntoConstraints = false
-        return scrollView
-    }()
-    
-    private var containerView: UIView = {
-        let view: UIView = UIView()
-        view.translatesAutoresizingMaskIntoConstraints = false
-        return view
-    }()
-    
-    private var titleLabel: UILabel = {
-        let label: UILabel = UILabel()
-        label.text = "주문 상품 목록"
-        label.font = CPFont.UIKit.m17
-        label.textColor = CPColor.UIKit.bk
-        label.translatesAutoresizingMaskIntoConstraints = false
-        return label
-    }()
-    
-    private var purchaseItemStackView: UIStackView = {
-        let stackView: UIStackView = UIStackView()
-        stackView.axis = .vertical
-        stackView.alignment = .fill
-        stackView.distribution = .fill
-        stackView.spacing = 7
-        stackView.translatesAutoresizingMaskIntoConstraints = false
-        return stackView
-    }()
-    
-    private var purchaseButton: UIButton = {
-        let button: UIButton = UIButton()
-        button.setTitle("결제하기", for: .normal)
-        button.setTitleColor(CPColor.UIKit.wh, for: .normal)
-        button.layer.backgroundColor = CPColor.UIKit.keyColorBlue.cgColor
-        button.layer.cornerRadius = 5
-        button.translatesAutoresizingMaskIntoConstraints = false
-        return button
-    }()
+    override func loadView() {
+        view = rootView
+    }
     
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .systemBackground
-        addSubView()
         bindViewModel()
         viewModel.process(.loadData)
-    }
-    
-    override func updateViewConstraints() {
-        if scrollViewConstraints == nil {
-            let constraints = [
-                scrollView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
-                scrollView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
-                scrollView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
-                scrollView.bottomAnchor.constraint(equalTo: purchaseButton.topAnchor),
-                
-                containerView.topAnchor.constraint(equalTo: scrollView.topAnchor),
-                containerView.leadingAnchor.constraint(equalTo: scrollView.leadingAnchor),
-                containerView.trailingAnchor.constraint(equalTo: scrollView.trailingAnchor),
-                containerView.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor),
-                containerView.widthAnchor.constraint(equalTo: scrollView.widthAnchor)
-            ]
-            NSLayoutConstraint.activate(constraints)
-            scrollViewConstraints = constraints
-        }
-        
-        if titleLabelConstraints == nil, let superView = titleLabel.superview {
-            let constraints = [
-                titleLabel.topAnchor.constraint(equalTo: superView.topAnchor, constant: 33),
-                titleLabel.leadingAnchor.constraint(equalTo: superView.leadingAnchor, constant: 33),
-                titleLabel.trailingAnchor.constraint(equalTo: superView.trailingAnchor, constant: -33),
-            ]
-            
-            NSLayoutConstraint.activate(constraints)
-            titleLabelConstraints = constraints
-        }
-        
-        if purchaseItemStackViewConstraints == nil, let superView = purchaseItemStackView.superview {
-            let constraints = [
-                purchaseItemStackView.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 19),
-                purchaseItemStackView.leadingAnchor.constraint(equalTo: superView.leadingAnchor, constant: 20),
-                purchaseItemStackView.trailingAnchor.constraint(equalTo: superView.trailingAnchor, constant: -20),
-                purchaseItemStackView.bottomAnchor.constraint(equalTo: superView.bottomAnchor, constant: -33)
-            ]
-            
-            NSLayoutConstraint.activate(constraints)
-            purchaseItemStackViewConstraints = constraints
-        }
-        
-        if purchaseButtonConstraints == nil{
-            let constraints = [
-                purchaseButton.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 20),
-                purchaseButton.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -20),
-                purchaseButton.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -32),
-                purchaseButton.heightAnchor.constraint(equalToConstant: 50)
-            ]
-            
-            NSLayoutConstraint.activate(constraints)
-            purchaseButtonConstraints = constraints
-        }
-        
-        super.updateViewConstraints()
-    }
-    
-    private func addSubView() {
-        view.addSubview(scrollView)
-        scrollView.addSubview(containerView)
-        containerView.addSubview(titleLabel)
-        containerView.addSubview(purchaseItemStackView)
-        view.addSubview(purchaseButton)
     }
     
     private func bindViewModel() {
         viewModel.$state
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
-                self?.purchaseItemStackView.arrangedSubviews.forEach {
-                    $0.removeFromSuperview()
-                }
+                guard let viewModel = self?.viewModel.state.purchaseItems else { return }
                 
-                self?.viewModel.state.purchaseItems?.forEach {
-                    self?.purchaseItemStackView.addArrangedSubview(PurchaseSelectedItemView(viewModel: $0))
-                }
+                self?.rootView.setPurchaseItem(viewModel)
             }
             .store(in: &cancellables)
     }

--- a/Cproject/Feature/Purchase/View/PurchaseRootView.swift
+++ b/Cproject/Feature/Purchase/View/PurchaseRootView.swift
@@ -1,0 +1,146 @@
+//
+//  PurchaseRootView.swift
+//  Cproject
+//
+//  Created by wodnd on 4/21/25.
+//
+
+import UIKit
+
+final class PurchaseRootView: UIView {
+
+    private var scrollViewConstraints: [NSLayoutConstraint]?
+    private var titleLabelConstraints: [NSLayoutConstraint]?
+    private var purchaseItemStackViewConstraints: [NSLayoutConstraint]?
+    private var purchaseButtonConstraints: [NSLayoutConstraint]?
+    
+    private var scrollView: UIScrollView = {
+        let scrollView: UIScrollView = UIScrollView()
+        scrollView.alwaysBounceVertical = true
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        return scrollView
+    }()
+    
+    private var containerView: UIView = {
+        let view: UIView = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+    
+    private var titleLabel: UILabel = {
+        let label: UILabel = UILabel()
+        label.text = "주문 상품 목록"
+        label.font = CPFont.UIKit.m17
+        label.textColor = CPColor.UIKit.bk
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+    
+    private var purchaseItemStackView: UIStackView = {
+        let stackView: UIStackView = UIStackView()
+        stackView.axis = .vertical
+        stackView.alignment = .fill
+        stackView.distribution = .fill
+        stackView.spacing = 7
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        return stackView
+    }()
+    
+    private var purchaseButton: UIButton = {
+        let button: UIButton = UIButton()
+        button.setTitle("결제하기", for: .normal)
+        button.setTitleColor(CPColor.UIKit.wh, for: .normal)
+        button.layer.backgroundColor = CPColor.UIKit.keyColorBlue.cgColor
+        button.layer.cornerRadius = 5
+        button.translatesAutoresizingMaskIntoConstraints = false
+        return button
+    }()
+    
+    override func updateConstraints() {
+        if scrollViewConstraints == nil {
+            let constraints = [
+                scrollView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor),
+                scrollView.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor),
+                scrollView.trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor),
+                scrollView.bottomAnchor.constraint(equalTo: purchaseButton.topAnchor),
+                
+                containerView.topAnchor.constraint(equalTo: scrollView.topAnchor),
+                containerView.leadingAnchor.constraint(equalTo: scrollView.leadingAnchor),
+                containerView.trailingAnchor.constraint(equalTo: scrollView.trailingAnchor),
+                containerView.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor),
+                containerView.widthAnchor.constraint(equalTo: scrollView.widthAnchor)
+            ]
+            NSLayoutConstraint.activate(constraints)
+            scrollViewConstraints = constraints
+        }
+        
+        if titleLabelConstraints == nil, let superView = titleLabel.superview {
+            let constraints = [
+                titleLabel.topAnchor.constraint(equalTo: superView.topAnchor, constant: 33),
+                titleLabel.leadingAnchor.constraint(equalTo: superView.leadingAnchor, constant: 33),
+                titleLabel.trailingAnchor.constraint(equalTo: superView.trailingAnchor, constant: -33),
+            ]
+            
+            NSLayoutConstraint.activate(constraints)
+            titleLabelConstraints = constraints
+        }
+        
+        if purchaseItemStackViewConstraints == nil, let superView = purchaseItemStackView.superview {
+            let constraints = [
+                purchaseItemStackView.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 19),
+                purchaseItemStackView.leadingAnchor.constraint(equalTo: superView.leadingAnchor, constant: 20),
+                purchaseItemStackView.trailingAnchor.constraint(equalTo: superView.trailingAnchor, constant: -20),
+                purchaseItemStackView.bottomAnchor.constraint(equalTo: superView.bottomAnchor, constant: -33)
+            ]
+            
+            NSLayoutConstraint.activate(constraints)
+            purchaseItemStackViewConstraints = constraints
+        }
+        
+        if purchaseButtonConstraints == nil{
+            let constraints = [
+                purchaseButton.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor, constant: 20),
+                purchaseButton.trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor, constant: -20),
+                purchaseButton.bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor, constant: -32),
+                purchaseButton.heightAnchor.constraint(equalToConstant: 50)
+            ]
+            
+            NSLayoutConstraint.activate(constraints)
+            purchaseButtonConstraints = constraints
+        }
+        
+        super.updateConstraints()
+    }
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        commonInit()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func commonInit() {
+        addSubView()
+    }
+    
+    private func addSubView() {
+        addSubview(scrollView)
+        scrollView.addSubview(containerView)
+        containerView.addSubview(titleLabel)
+        containerView.addSubview(purchaseItemStackView)
+        addSubview(purchaseButton)
+    }
+    
+    func setPurchaseItem(_ viewModel: [PurchaseSelectedItemViewModel]){
+        purchaseItemStackView.arrangedSubviews.forEach {
+            $0.removeFromSuperview()
+        }
+        
+        viewModel.forEach {
+            purchaseItemStackView.addArrangedSubview(PurchaseSelectedItemView(viewModel: $0))
+        }
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
[REFACTOR] View를 VC로 부터 분리 작업 #33

## ✨ 이슈 내용
<!-- 이슈에 대한 설명을 적어주세요 -->
1. View를 VC로 부터 분리 작업

## ‼️ TODO
<!-- 해결하지 못했거나 추후 해야할 일에 대한 설명을 적어주세요 -->

## 📸 코드 및 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->
1. View를 VC로 부터 분리 작업
```swift
final class PurchaseViewController: UIViewController {
    private var cancellables: Set<AnyCancellable> = []
    private var viewModel: PurchaseViewModel = PurchaseViewModel()
    private var rootView: PurchaseRootView = PurchaseRootView()
    
    override func loadView() {
        view = rootView
    }
    
    override func viewDidLoad() {
        super.viewDidLoad()
        view.backgroundColor = .systemBackground
        bindViewModel()
        viewModel.process(.loadData)
    }
    
    private func bindViewModel() {
        viewModel.$state
            .receive(on: DispatchQueue.main)
            .sink { [weak self] _ in
                guard let viewModel = self?.viewModel.state.purchaseItems else { return }
                
                self?.rootView.setPurchaseItem(viewModel)
            }
            .store(in: &cancellables)
    }
}
```

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
### 1. 코드 분리 작업

#### ✅ 1) 함수 변경 작업
UIView Cocoa Touch Class 파일로 옮김으로써 앞써 사용하였던 updateViewConstraints 함수를 `updateConstraints`로 변경해주어야 합니다. 전체적으로 UIView가 기본이기에 view.를 참조한 코드들은 `view.를 삭제`해야 합니다. 

#### ✅ 2) rootView 변경 작업
View에 해당하는 코드를 분리후 VC에서 호출 시 최상위 View를 교체 해줘야함으로써 `loadView 함수`를 호출하여 최상위 View를 변경해야 합니다. 
